### PR TITLE
Version: 1.6.9

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab

--- a/getwid.php
+++ b/getwid.php
@@ -3,7 +3,7 @@
  * Plugin Name: Getwid
  * Plugin URI: https://motopress.com/products/getwid/
  * Description: Extra Gutenberg blocks for building seamless and aesthetic websites in the WordPress block editor.
- * Version: 1.6.8
+ * Version: 1.6.9
  * Author: MotoPress
  * Author URI: https://motopress.com/
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ Getwid plugin is distributed under the terms of the GNU GPL.
 
 == Changelog ==
 
+= 1.6.9, Dec 17 2020 =
+* Fixed an issue when some blocks may grow infinitely wide in WordPress 5.6.
+
 = 1.6.8, Dec 14 2020 =
 * Improved compatibility with WordPress 5.6.
 * Added support for an H1 HTML tag to the Table of Contents block.

--- a/src/blocks/toggle/toggle/style.scss
+++ b/src/blocks/toggle/toggle/style.scss
@@ -26,7 +26,7 @@
 				}
 
 				&.is-passive {
-					display: initial;
+					display: inline;
 				}
 			}
 

--- a/src/common-editor-blocks-styles.scss
+++ b/src/common-editor-blocks-styles.scss
@@ -73,7 +73,9 @@
 }
 
 /*
- * TODO: WordPress 5.6 Select Multiple Fix
+ * TODO: WordPress 5.6 Fix
+ * Select Multiple
+ * https://github.com/WordPress/gutenberg/issues/27166
  */
 body.branch-5-6 {
 	.components-select-control.getwid-wp56-fix,
@@ -86,4 +88,16 @@ body.branch-5-6 {
 			display: none !important;
 		}
 	}
+}
+
+
+/*
+ * TODO: WordPress 5.6 Fix
+ * Limit the editor width to prevent some blocks to grow infinitely wide
+ * https://github.com/WordPress/gutenberg/pull/27695
+ * https://github.com/WordPress/gutenberg/issues/27622
+ *
+ */
+.interface-interface-skeleton__editor {
+	overflow: hidden;
 }


### PR DESCRIPTION
Limit the editor width to prevent some blocks to grow infinitely wide.