### PR TITLE
Expose Slick's `adaptiveHeight` and `draggable` for content slider

### DIFF
--- a/src/blocks/content-slider/content-slider/attributes.js
+++ b/src/blocks/content-slider/content-slider/attributes.js
@@ -44,6 +44,20 @@ const attributes = {
 		attribute: 'data-center-mode',
 		default: false
 	},
+	adaptiveHeight: {
+		type: 'boolean',
+		source: 'attribute',
+		selector: '.wp-block-getwid-content-slider',
+		attribute: 'data-adaptive-height',
+		default: false
+	},
+	draggable: {
+		type: 'boolean',
+		source: 'attribute',
+		selector: '.wp-block-getwid-content-slider',
+		attribute: 'data-draggable',
+		default: true
+	},
 	pauseOnHover: {
 		type: 'boolean',
 		source: 'attribute',

--- a/src/blocks/content-slider/content-slider/inspector.js
+++ b/src/blocks/content-slider/content-slider/inspector.js
@@ -48,6 +48,8 @@ class Inspector extends Component {
 				animationSpeed,
 				autoplaySpeed,
 				centerMode,
+				adaptiveHeight,
+				draggable,
 				pauseOnHover,
 				arrows,
 				dots,
@@ -92,6 +94,20 @@ class Inspector extends Component {
 						checked={ centerMode }
 						onChange={ () => {
 							setAttributes( { centerMode: !centerMode } );
+						} }
+					/>
+					<ToggleControl
+						label={ __( 'Adaptive Height', 'getwid' ) }
+						checked={ adaptiveHeight }
+						onChange={ () => {
+							setAttributes( { adaptiveHeight: !adaptiveHeight } );
+						} }
+					/>
+					<ToggleControl
+						label={ __( 'Draggable', 'getwid' ) }
+						checked={ draggable }
+						onChange={ () => {
+							setAttributes( { draggable: !draggable } );
 						} }
 					/>
 					<SelectControl

--- a/src/blocks/content-slider/content-slider/save.js
+++ b/src/blocks/content-slider/content-slider/save.js
@@ -31,6 +31,8 @@ class Save extends Component {
 			'infinite',
 			'animationEffect',
 			'centerMode',
+			'adaptiveHeight',
+			'draggable',
 			'pauseOnHover',
 			'arrows',
 			'dots',

--- a/src/frontend/blocks/content-slider/index.js
+++ b/src/frontend/blocks/content-slider/index.js
@@ -1,5 +1,5 @@
 /*!
- * getwid-images-slider
+ * getwid-content-slider
  */
 
 (function ($) {
@@ -32,6 +32,8 @@
 					infinite: !!sliderRoot.data('infinite'),
 					fade: sliderRoot.data('effect') === 'fade',
 					centerMode: !!sliderRoot.data('center-mode'),
+					adaptiveHeight: !!sliderRoot.data('adaptive-height') ?? false,
+					draggable: !!sliderRoot.data('draggable') ?? true,
 					pauseOnHover: !!sliderRoot.data('pause-hover'),
 					rows: 0,
 					slidesToShow: sliderRoot.data('slides-show') ?? 1,


### PR DESCRIPTION
Hello 👋,

This PR adds attributes to control the `adaptiveHeight` and `draggable` options for the content slider block.

When `draggable` is true, desktop users cannot highlight text to copy, search with Google, etc. This is not very ideal, especially when you have a lot of text in the content slider.

`adaptiveHeight` is also very useful in this case. When you have content slides with very different heights, a lot of extra space is wasted on the smaller slides.

I've made the default values match what they currently are, to avoid breaking changes.

Please let me know if there's anything else that needs to be done.