### PR TITLE
Map: Add Support for Custom Marker Icon

### DIFF
--- a/includes/scripts-manager.php
+++ b/includes/scripts-manager.php
@@ -159,10 +159,11 @@ class ScriptsManager {
 						'assets_path' => getwid_get_plugin_url( '/assets' ),
 						'image_sizes' => $this->get_image_sizes(),
 
-						'excerpt_length'       => apply_filters( 'excerpt_length', 55 ),
-						'recaptcha_site_key'   => get_option( 'getwid_recaptcha_v2_site_key'  , '' ),
-						'recaptcha_secret_key' => get_option( 'getwid_recaptcha_v2_secret_key', '' ),
-						'mailchimp_api_key'    => get_option( 'getwid_mailchimp_api_key'      , '' ),
+						'excerpt_length'          => apply_filters( 'excerpt_length', 55 ),
+						'recaptcha_site_key'      => get_option( 'getwid_recaptcha_v2_site_key'  , '' ),
+						'recaptcha_secret_key'    => get_option( 'getwid_recaptcha_v2_secret_key', '' ),
+						'mailchimp_api_key'       => get_option( 'getwid_mailchimp_api_key'      , '' ),
+						'google_maps_marker_icon' => get_option( 'getwid_google_maps_marker_icon', '' ),
 						'debug' => ( defined( 'WP_DEBUG' ) ? WP_DEBUG : false )
 					],
 					'templates' => [
@@ -273,7 +274,9 @@ class ScriptsManager {
 			apply_filters(
 				'getwid/frontend_blocks_js/localize_data',
 				[
-					'settings' => [],
+					'settings' => [
+						'google_maps_marker_icon' => get_option( 'getwid_google_maps_marker_icon', '' )
+					],
 					'ajax_url' => admin_url( 'admin-ajax.php' ),
 					'isRTL' => is_rtl(),
 					'nonces' => array(

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -172,6 +172,12 @@ class SettingsPage {
 		register_setting( 'getwid_appearance', 'getwid_smooth_animation', [ 'type' => 'boolean', 'default' => false, 'sanitize_callback' => 'rest_sanitize_boolean' ] );
 		/* #endregion */
 
+		/* #region Google Maps Marker Icon */
+		add_settings_field( 'getwid_google_maps_marker_icon', __( 'Google Maps Marker Icon', 'getwid' ),
+				[ $this, 'renderGoogleMapsMarkerIcon' ], 'getwid_appearance', 'getwid_appearance' );
+		register_setting( 'getwid_appearance', 'getwid_google_maps_marker_icon', [ 'type' => 'url', 'default' => '' ] );
+		/* #endregion */
+
 		/* #region AssetsOptimization */
 		add_settings_field( 'getwid_assets_optimization', __( 'Performance Optimization', 'getwid' ) . ' (Beta)',
 				[ $this, 'renderAssetsOptimization'], 'getwid_general', 'getwid_general' );
@@ -378,6 +384,17 @@ class SettingsPage {
 		</label>
 		<p class="description"><?php
 			echo esc_html__('Hides block until the entrance animation starts. Prevents possible occurrence of horizontal scroll during the animation.', 'getwid');
+			?></p>
+		<?php
+	}
+
+	public function renderGoogleMapsMarkerIcon() {
+
+		$field_val = get_option( 'getwid_google_maps_marker_icon', false );
+		?>
+		<input type="url" id="getwid_google_maps_marker_icon" name="getwid_google_maps_marker_icon" class="regular-text" value="<?php echo esc_attr( $field_val ); ?>" />
+		<p class="description"><?php
+			echo esc_html__('Image URL to use as default marker icon.', 'getwid');
 			?></p>
 		<?php
 	}

--- a/src/blocks/map/edit.js
+++ b/src/blocks/map/edit.js
@@ -438,12 +438,15 @@ class Edit extends Component {
 
 		const latLng = mapMarkersParsed[markerID].coords;
 
+		const { iconUrl = Getwid.settings.google_maps_marker_icon } = mapMarkersParsed[markerID];
+
 		let marker;
 
 		if (refreshMarker == false) {
 			marker = new google.maps.Marker({
 				id: markerID,
 				position: latLng,
+				icon: iconUrl,
 				map: googleMap,
 				draggable: true,
 				animation: firstInit ? google.maps.Animation.DROP : null,
@@ -458,6 +461,7 @@ class Edit extends Component {
 		} else {
 			marker = markerArrTemp[markerID];
 			marker.setPosition( latLng );
+			marker.setIcon( iconUrl );
 		}
 
 		let message = '';

--- a/src/blocks/map/inspector.js
+++ b/src/blocks/map/inspector.js
@@ -17,6 +17,7 @@ const {
 } = wp.element;
 const {
 	InspectorControls,
+	MediaUpload,
 } = wp.blockEditor || wp.editor;
 const {
 	Button,
@@ -280,6 +281,54 @@ class Inspector extends Component {
 									}
 								}, index );
 							}}
+						/>
+
+						<MediaUpload
+							onSelect={ media => {
+								updateArrValues( {
+									iconId: media.id,
+									iconUrl: media.url
+								}, index );
+							} }
+							allowedTypes={'image/*'}
+							value={ mapMarkersParsed[ index ].iconId }
+							render={ ( { open } ) => (
+								<BaseControl label={__('Icon', 'getwid')}>
+									{!!mapMarkersParsed[ index ].iconUrl && (
+										<figure onClick={ open }>
+											<img src={mapMarkersParsed[ index ].iconUrl} />
+										</figure>
+									)}
+
+									<div>
+										<Button
+											isSecondary
+											onClick={ open }
+										>
+											<Fragment>
+												{!mapMarkersParsed[ index ].iconId && __('Select Icon', 'getwid')}
+												{!!mapMarkersParsed[ index ].iconId && __('Replace Icon', 'getwid')}
+											</Fragment>
+										</Button>
+
+										{!!mapMarkersParsed[ index ].iconId && (
+											<Button
+												isDestructive
+												isLink
+												onClick={ () => {
+													updateArrValues( {
+														iconId: undefined,
+														iconUrl: undefined
+													}, index );
+												} }
+												style={ { marginTop: '1em' } }
+											>
+												{__('Remove marker icon', 'getwid')}
+											</Button>
+										)}
+									</div>
+								</BaseControl>
+							) }
 						/>
 
 						<ButtonGroup>

--- a/src/frontend/blocks/map/index.js
+++ b/src/frontend/blocks/map/index.js
@@ -131,8 +131,11 @@
 
 			const latLng = mapMarkers[markerID].coords;
 
+			const { iconUrl = Getwid.settings.google_maps_marker_icon } = mapMarkers[markerID];
+
 			const marker = new google.maps.Marker( {
 				position: latLng,
+				icon: iconUrl,
 				map: googleMap,
 				draggable: false,
 				animation: google.maps.Animation.DROP,


### PR DESCRIPTION
👋 Hey there!

First of all, this is a really great collection of blocks! Thanks for this! 👏

----

Now, I really like the Map block, allowing to integrate one of more customizable Google Maps maps into a post. One thing that was missing for me was the ability to use custom marker icons.

Using the [Google Maps JavaScript API](https://developers.google.com/maps/documentation/javascript/custom-markers), this is as easy as [passing an icon URL to a marker](https://developers.google.com/maps/documentation/javascript/custom-markers#customizing_a_map_marker) while or after creating it.

This PR adds support for marker icons. 🎉

**Block Edit View:**  
![image](https://user-images.githubusercontent.com/6049306/191671682-cd52b66f-96ce-42fd-a8a4-4beff7fc3a58.png)

**Inspector Controls:**  
![image](https://user-images.githubusercontent.com/6049306/191671793-fd30cebb-1e2b-4531-bbb3-11d6d8f91e61.png)

![image](https://user-images.githubusercontent.com/6049306/191671891-e4969bb1-52b6-447c-8cfb-0ac14c7a224c.png)

**Front End:**  
![image](https://user-images.githubusercontent.com/6049306/191672277-5989f9d5-22ff-4ccf-aa70-6924a939c465.png)

----

I also added a new settings field for defining the URL to use as default marker icon.

![image](https://user-images.githubusercontent.com/6049306/191677338-81c3f51a-2344-486f-a310-936eda998bdc.png)

----

Feel free to suggest or make changes to my code.
I tried to follow your coding standards, but I found there were some inconsistencies around formatting etc. here and there.

Also, I integrated the exact same controls into the Edit Modal, but took it out again. The reason being that opening the Media Modal for selecting the icon will automatically have the Edit Modal for the Marker get closed.