### PR TITLE
Make method block_frontend_assets() public

### DIFF
--- a/includes/blocks/accordion.php
+++ b/includes/blocks/accordion.php
@@ -46,7 +46,7 @@ class Accordion extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/advanced-heading.php
+++ b/includes/blocks/advanced-heading.php
@@ -22,7 +22,7 @@ class AdvancedHeading extends \Getwid\Blocks\AbstractBlock {
 		return __('Advanced Heading', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/advanced-spacer.php
+++ b/includes/blocks/advanced-spacer.php
@@ -23,7 +23,7 @@ class AdvancedSpacer extends \Getwid\Blocks\AbstractBlock {
 		return __('Advanced Spacer', 'getwid');
 	}
 
-    private function block_frontend_assets( $attributes = null ) {
+    public function block_frontend_assets( $attributes = null ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/banner.php
+++ b/includes/blocks/banner.php
@@ -22,7 +22,7 @@ class Banner extends \Getwid\Blocks\AbstractBlock {
 		return __('Banner', 'getwid');
 	}
 
-    private function block_frontend_assets( $attributes = null ) {
+    public function block_frontend_assets( $attributes = null ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/circle-progress-bar.php
+++ b/includes/blocks/circle-progress-bar.php
@@ -31,7 +31,7 @@ class CircleProgressBar extends \Getwid\Blocks\AbstractBlock {
 		return __('Circular Progress Bar', 'getwid');
 	}
 
-    private function block_frontend_assets( $attributes = null ) {
+    public function block_frontend_assets( $attributes = null ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/contact-form.php
+++ b/includes/blocks/contact-form.php
@@ -114,7 +114,7 @@ class ContactForm extends \Getwid\Blocks\AbstractBlock {
     }
     /* #endregion */
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/content-slider.php
+++ b/includes/blocks/content-slider.php
@@ -77,7 +77,7 @@ class ContentSlider extends AbstractBlock {
 		return $scripts;
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/content-timeline.php
+++ b/includes/blocks/content-timeline.php
@@ -23,7 +23,7 @@ class ContentTimeline extends \Getwid\Blocks\AbstractBlock {
 		return __('Content Timeline', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/countdown.php
+++ b/includes/blocks/countdown.php
@@ -184,7 +184,7 @@ class Countdown extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/counter.php
+++ b/includes/blocks/counter.php
@@ -54,7 +54,7 @@ class Counter extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/custom-post-type.php
+++ b/includes/blocks/custom-post-type.php
@@ -130,7 +130,7 @@ class CustomPostType extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/google-map.php
+++ b/includes/blocks/google-map.php
@@ -79,7 +79,7 @@ class GoogleMap extends \Getwid\Blocks\AbstractBlock {
         wp_send_json_success( $response );
     }
 
-    private function block_frontend_assets( $attributes = [], $content = '' ) {
+    public function block_frontend_assets( $attributes = [], $content = '' ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/image-hotspot.php
+++ b/includes/blocks/image-hotspot.php
@@ -126,7 +126,7 @@ class ImageHotspot extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/images-slider.php
+++ b/includes/blocks/images-slider.php
@@ -82,7 +82,7 @@ class ImageSlider extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/images-stack.php
+++ b/includes/blocks/images-stack.php
@@ -23,7 +23,7 @@ class ImagesStack extends \Getwid\Blocks\AbstractBlock {
 		return __('Image Stack Gallery', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/instagram.php
+++ b/includes/blocks/instagram.php
@@ -71,7 +71,7 @@ class Instagram extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/mailchimp.php
+++ b/includes/blocks/mailchimp.php
@@ -62,7 +62,7 @@ class MailChimp extends \Getwid\Blocks\AbstractBlock {
         /* #endregion */
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/media-text-slider.php
+++ b/includes/blocks/media-text-slider.php
@@ -84,7 +84,7 @@ class MediaTextSlider extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/person.php
+++ b/includes/blocks/person.php
@@ -23,7 +23,7 @@ class Person extends \Getwid\Blocks\AbstractBlock {
 		return __('Person', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/post-carousel.php
+++ b/includes/blocks/post-carousel.php
@@ -219,7 +219,7 @@ class PostCarousel extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/post-slider.php
+++ b/includes/blocks/post-slider.php
@@ -207,7 +207,7 @@ class PostSlider extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/price-box.php
+++ b/includes/blocks/price-box.php
@@ -23,7 +23,7 @@ class PriceBox extends \Getwid\Blocks\AbstractBlock {
 		return __('Price Box', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/price-list.php
+++ b/includes/blocks/price-list.php
@@ -23,7 +23,7 @@ class PriceList extends \Getwid\Blocks\AbstractBlock {
 		return __('Price List', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/progress-bar.php
+++ b/includes/blocks/progress-bar.php
@@ -31,7 +31,7 @@ class ProgressBar extends \Getwid\Blocks\AbstractBlock {
 		return __('Progress Bar', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/recent-posts.php
+++ b/includes/blocks/recent-posts.php
@@ -94,7 +94,7 @@ class RecentPosts extends \Getwid\Blocks\AbstractBlock {
 		return __('Recent Posts', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/section.php
+++ b/includes/blocks/section.php
@@ -118,7 +118,7 @@ class Section extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets( $attributes = [], $content = '' ) {
+    public function block_frontend_assets( $attributes = [], $content = '' ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/social-links.php
+++ b/includes/blocks/social-links.php
@@ -35,7 +35,7 @@ class SocialLinks extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/table-of-contents.php
+++ b/includes/blocks/table-of-contents.php
@@ -31,7 +31,7 @@ class TableOfContents extends \Getwid\Blocks\AbstractBlock {
 		return __('Table of Contents', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/table.php
+++ b/includes/blocks/table.php
@@ -22,7 +22,7 @@ class Table extends \Getwid\Blocks\AbstractBlock {
 		return __( 'Table', 'getwid' );
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/tabs.php
+++ b/includes/blocks/tabs.php
@@ -37,7 +37,7 @@ class Tabs extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/acf/background-image.php
+++ b/includes/blocks/template-parts/acf/background-image.php
@@ -160,7 +160,7 @@ class AcfBackgroundImage extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/acf/image.php
+++ b/includes/blocks/template-parts/acf/image.php
@@ -39,7 +39,7 @@ class AcfImage extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/acf/select.php
+++ b/includes/blocks/template-parts/acf/select.php
@@ -62,7 +62,7 @@ class AcfSelect extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/acf/wysiwyg.php
+++ b/includes/blocks/template-parts/acf/wysiwyg.php
@@ -55,7 +55,7 @@ class AcfWysiwyg extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/post-author.php
+++ b/includes/blocks/template-parts/post-author.php
@@ -62,7 +62,7 @@ class PostAuthor extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-button.php
+++ b/includes/blocks/template-parts/post-button.php
@@ -47,7 +47,7 @@ class PostButton extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-categories.php
+++ b/includes/blocks/template-parts/post-categories.php
@@ -67,7 +67,7 @@ class PostCategories extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-comments.php
+++ b/includes/blocks/template-parts/post-comments.php
@@ -63,7 +63,7 @@ class PostComments extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-content.php
+++ b/includes/blocks/template-parts/post-content.php
@@ -50,7 +50,7 @@ class PostContent extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-custom-field.php
+++ b/includes/blocks/template-parts/post-custom-field.php
@@ -53,7 +53,7 @@ class PostCustomField extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-date.php
+++ b/includes/blocks/template-parts/post-date.php
@@ -70,7 +70,7 @@ class PostDate extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-featured-background-image.php
+++ b/includes/blocks/template-parts/post-featured-background-image.php
@@ -161,7 +161,7 @@ class PostFeaturedBackgroundImage extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-featured-image.php
+++ b/includes/blocks/template-parts/post-featured-image.php
@@ -36,7 +36,7 @@ class PostFeaturedImage extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-link.php
+++ b/includes/blocks/template-parts/post-link.php
@@ -41,7 +41,7 @@ class PostLink extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-meta.php
+++ b/includes/blocks/template-parts/post-meta.php
@@ -45,7 +45,7 @@ class PostMeta extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-tags.php
+++ b/includes/blocks/template-parts/post-tags.php
@@ -66,7 +66,7 @@ class PostTags extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-title.php
+++ b/includes/blocks/template-parts/post-title.php
@@ -58,7 +58,7 @@ class PostTitle extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/testimonial.php
+++ b/includes/blocks/testimonial.php
@@ -23,7 +23,7 @@ class Testimonial extends \Getwid\Blocks\AbstractBlock {
 		return __('Testimonial', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/toggle.php
+++ b/includes/blocks/toggle.php
@@ -41,7 +41,7 @@ class Toggle extends \Getwid\Blocks\AbstractBlock {
         return $styles;
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/video-popup.php
+++ b/includes/blocks/video-popup.php
@@ -56,7 +56,7 @@ class VideoPopup extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;


### PR DESCRIPTION
In order to allow loading assets for getwid blocks generated from outside getwid.

https://wordpress.org/support/topic/make-method-block_frontend_assets-public/