### PR TITLE
Version 1.8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 /stats.json
 /src/blocks/all-blocks
+*.code-workspace

--- a/getwid.php
+++ b/getwid.php
@@ -3,7 +3,7 @@
  * Plugin Name: Getwid
  * Plugin URI: https://motopress.com/products/getwid/
  * Description: Extra Gutenberg blocks for building seamless and aesthetic websites in the WordPress block editor.
- * Version: 1.8.2
+ * Version: 1.8.3
  * Author: MotoPress
  * Author URI: https://motopress.com/
  * License: GPLv2 or later

--- a/includes/blocks/accordion.php
+++ b/includes/blocks/accordion.php
@@ -46,7 +46,7 @@ class Accordion extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/advanced-heading.php
+++ b/includes/blocks/advanced-heading.php
@@ -22,7 +22,7 @@ class AdvancedHeading extends \Getwid\Blocks\AbstractBlock {
 		return __('Advanced Heading', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/advanced-spacer.php
+++ b/includes/blocks/advanced-spacer.php
@@ -23,7 +23,7 @@ class AdvancedSpacer extends \Getwid\Blocks\AbstractBlock {
 		return __('Advanced Spacer', 'getwid');
 	}
 
-    private function block_frontend_assets( $attributes = null ) {
+    public function block_frontend_assets( $attributes = null ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/banner.php
+++ b/includes/blocks/banner.php
@@ -22,7 +22,7 @@ class Banner extends \Getwid\Blocks\AbstractBlock {
 		return __('Banner', 'getwid');
 	}
 
-    private function block_frontend_assets( $attributes = null ) {
+    public function block_frontend_assets( $attributes = null ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/circle-progress-bar.php
+++ b/includes/blocks/circle-progress-bar.php
@@ -31,7 +31,7 @@ class CircleProgressBar extends \Getwid\Blocks\AbstractBlock {
 		return __('Circular Progress Bar', 'getwid');
 	}
 
-    private function block_frontend_assets( $attributes = null ) {
+    public function block_frontend_assets( $attributes = null ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/contact-form.php
+++ b/includes/blocks/contact-form.php
@@ -114,7 +114,7 @@ class ContactForm extends \Getwid\Blocks\AbstractBlock {
     }
     /* #endregion */
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/content-slider.php
+++ b/includes/blocks/content-slider.php
@@ -77,7 +77,7 @@ class ContentSlider extends AbstractBlock {
 		return $scripts;
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/content-timeline.php
+++ b/includes/blocks/content-timeline.php
@@ -23,7 +23,7 @@ class ContentTimeline extends \Getwid\Blocks\AbstractBlock {
 		return __('Content Timeline', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/countdown.php
+++ b/includes/blocks/countdown.php
@@ -184,7 +184,7 @@ class Countdown extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/counter.php
+++ b/includes/blocks/counter.php
@@ -54,7 +54,7 @@ class Counter extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/custom-post-type.php
+++ b/includes/blocks/custom-post-type.php
@@ -130,7 +130,7 @@ class CustomPostType extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/google-map.php
+++ b/includes/blocks/google-map.php
@@ -79,7 +79,7 @@ class GoogleMap extends \Getwid\Blocks\AbstractBlock {
         wp_send_json_success( $response );
     }
 
-    private function block_frontend_assets( $attributes = [], $content = '' ) {
+    public function block_frontend_assets( $attributes = [], $content = '' ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/image-hotspot.php
+++ b/includes/blocks/image-hotspot.php
@@ -126,7 +126,7 @@ class ImageHotspot extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/images-slider.php
+++ b/includes/blocks/images-slider.php
@@ -82,7 +82,7 @@ class ImageSlider extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/images-stack.php
+++ b/includes/blocks/images-stack.php
@@ -23,7 +23,7 @@ class ImagesStack extends \Getwid\Blocks\AbstractBlock {
 		return __('Image Stack Gallery', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/instagram.php
+++ b/includes/blocks/instagram.php
@@ -71,7 +71,7 @@ class Instagram extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/mailchimp.php
+++ b/includes/blocks/mailchimp.php
@@ -62,7 +62,7 @@ class MailChimp extends \Getwid\Blocks\AbstractBlock {
         /* #endregion */
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/media-text-slider.php
+++ b/includes/blocks/media-text-slider.php
@@ -84,7 +84,7 @@ class MediaTextSlider extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/person.php
+++ b/includes/blocks/person.php
@@ -23,7 +23,7 @@ class Person extends \Getwid\Blocks\AbstractBlock {
 		return __('Person', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/post-carousel.php
+++ b/includes/blocks/post-carousel.php
@@ -219,7 +219,7 @@ class PostCarousel extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/post-slider.php
+++ b/includes/blocks/post-slider.php
@@ -207,7 +207,7 @@ class PostSlider extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/price-box.php
+++ b/includes/blocks/price-box.php
@@ -23,7 +23,7 @@ class PriceBox extends \Getwid\Blocks\AbstractBlock {
 		return __('Price Box', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/price-list.php
+++ b/includes/blocks/price-list.php
@@ -23,7 +23,7 @@ class PriceList extends \Getwid\Blocks\AbstractBlock {
 		return __('Price List', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/progress-bar.php
+++ b/includes/blocks/progress-bar.php
@@ -31,7 +31,7 @@ class ProgressBar extends \Getwid\Blocks\AbstractBlock {
 		return __('Progress Bar', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/recent-posts.php
+++ b/includes/blocks/recent-posts.php
@@ -94,7 +94,7 @@ class RecentPosts extends \Getwid\Blocks\AbstractBlock {
 		return __('Recent Posts', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
 		if ( is_admin() ) {
             return;

--- a/includes/blocks/section.php
+++ b/includes/blocks/section.php
@@ -118,7 +118,7 @@ class Section extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets( $attributes = [], $content = '' ) {
+    public function block_frontend_assets( $attributes = [], $content = '' ) {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/social-links.php
+++ b/includes/blocks/social-links.php
@@ -35,7 +35,7 @@ class SocialLinks extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/table-of-contents.php
+++ b/includes/blocks/table-of-contents.php
@@ -31,7 +31,7 @@ class TableOfContents extends \Getwid\Blocks\AbstractBlock {
 		return __('Table of Contents', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/table.php
+++ b/includes/blocks/table.php
@@ -22,7 +22,7 @@ class Table extends \Getwid\Blocks\AbstractBlock {
 		return __( 'Table', 'getwid' );
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/tabs.php
+++ b/includes/blocks/tabs.php
@@ -37,7 +37,7 @@ class Tabs extends \Getwid\Blocks\AbstractBlock {
         return $scripts;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/acf/background-image.php
+++ b/includes/blocks/template-parts/acf/background-image.php
@@ -160,7 +160,7 @@ class AcfBackgroundImage extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/acf/image.php
+++ b/includes/blocks/template-parts/acf/image.php
@@ -39,7 +39,7 @@ class AcfImage extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/acf/select.php
+++ b/includes/blocks/template-parts/acf/select.php
@@ -62,7 +62,7 @@ class AcfSelect extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/acf/wysiwyg.php
+++ b/includes/blocks/template-parts/acf/wysiwyg.php
@@ -55,7 +55,7 @@ class AcfWysiwyg extends \Getwid\Blocks\AbstractBlock {
 		);
 	}
 
-	private function block_frontend_assets() {
+	public function block_frontend_assets() {
 
 		if ( is_admin() ) {
 			return;

--- a/includes/blocks/template-parts/post-author.php
+++ b/includes/blocks/template-parts/post-author.php
@@ -62,7 +62,7 @@ class PostAuthor extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-button.php
+++ b/includes/blocks/template-parts/post-button.php
@@ -47,7 +47,7 @@ class PostButton extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-categories.php
+++ b/includes/blocks/template-parts/post-categories.php
@@ -67,7 +67,7 @@ class PostCategories extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-comments.php
+++ b/includes/blocks/template-parts/post-comments.php
@@ -63,7 +63,7 @@ class PostComments extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-content.php
+++ b/includes/blocks/template-parts/post-content.php
@@ -50,7 +50,7 @@ class PostContent extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-custom-field.php
+++ b/includes/blocks/template-parts/post-custom-field.php
@@ -53,7 +53,7 @@ class PostCustomField extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-date.php
+++ b/includes/blocks/template-parts/post-date.php
@@ -70,7 +70,7 @@ class PostDate extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-featured-background-image.php
+++ b/includes/blocks/template-parts/post-featured-background-image.php
@@ -161,7 +161,7 @@ class PostFeaturedBackgroundImage extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-featured-image.php
+++ b/includes/blocks/template-parts/post-featured-image.php
@@ -36,7 +36,7 @@ class PostFeaturedImage extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-link.php
+++ b/includes/blocks/template-parts/post-link.php
@@ -41,7 +41,7 @@ class PostLink extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-meta.php
+++ b/includes/blocks/template-parts/post-meta.php
@@ -45,7 +45,7 @@ class PostMeta extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-tags.php
+++ b/includes/blocks/template-parts/post-tags.php
@@ -66,7 +66,7 @@ class PostTags extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/template-parts/post-title.php
+++ b/includes/blocks/template-parts/post-title.php
@@ -58,7 +58,7 @@ class PostTitle extends \Getwid\Blocks\AbstractBlock {
         );
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/testimonial.php
+++ b/includes/blocks/testimonial.php
@@ -23,7 +23,7 @@ class Testimonial extends \Getwid\Blocks\AbstractBlock {
 		return __('Testimonial', 'getwid');
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/toggle.php
+++ b/includes/blocks/toggle.php
@@ -41,7 +41,7 @@ class Toggle extends \Getwid\Blocks\AbstractBlock {
         return $styles;
 	}
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/blocks/video-popup.php
+++ b/includes/blocks/video-popup.php
@@ -56,7 +56,7 @@ class VideoPopup extends \Getwid\Blocks\AbstractBlock {
         return $styles;
     }
 
-    private function block_frontend_assets() {
+    public function block_frontend_assets() {
 
         if ( is_admin() ) {
             return;

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -173,7 +173,7 @@ class SettingsPage {
 		/* #endregion */
 
 		/* #region AssetsOptimization */
-		add_settings_field( 'getwid_assets_optimization', __( 'Performance Optimization', 'getwid' ) . ' (Beta)',
+		add_settings_field( 'getwid_assets_optimization', __( 'Performance Optimization', 'getwid' ),
 				[ $this, 'renderAssetsOptimization'], 'getwid_general', 'getwid_general' );
 		register_setting( 'getwid_general', 'getwid_load_assets_on_demand', [ 'type' => 'boolean', 'default' => false, 'sanitize_callback' => 'rest_sanitize_boolean' ] );
 
@@ -236,7 +236,7 @@ class SettingsPage {
         ?>
 		<input type="number" id="getwid_section_content_width" name="getwid_section_content_width" value="<?php echo esc_attr( $field_val ); ?>" />
         <?php echo esc_html_x( 'px', 'pixels', 'getwid' ); ?>
-		<p class="description"><?php echo esc_html__( 'Default width of content area in the Section block. Leave empty to use the width set in your theme.', 'getwid' ); ?></p>
+		<p class="description"><?php echo esc_html__( 'Default width of content area in the Section block. Leave empty to use $content_width set in your theme. Set 0 to disable this option and control it via CSS.', 'getwid' ); ?></p>
 		<?php
     }
 
@@ -391,7 +391,7 @@ class SettingsPage {
 			<label for="getwid_load_assets_on_demand">
 				<input type="checkbox" id="getwid_load_assets_on_demand" name="getwid_load_assets_on_demand" value="1" <?php
 					checked( '1', $getwid_load_assets_on_demand ); ?> />
-				<?php echo esc_html__('Load CSS and JS of blocks on demand', 'getwid'); ?>
+				<?php echo esc_html__('Load CSS and JS of blocks on demand', 'getwid') . ' (Recomended)'; ?>
 			</label>
 			<p class="description"><?php
 				echo esc_html__('If this option is on, all CSS and JS files of blocks will be loaded on demand in footer. This will reduce the amount of heavy assets on the page.', 'getwid');
@@ -400,7 +400,7 @@ class SettingsPage {
 			<label for="getwid_move_css_to_head">
 				<input type="checkbox" id="getwid_move_css_to_head" name="getwid_move_css_to_head" value="1" <?php
 					checked( '1', $getwid_move_css_to_head ); ?> />
-				<?php echo esc_html__('Aggregate all CSS files of blocks in header', 'getwid'); ?>
+				<?php echo esc_html__('Aggregate all CSS files of blocks in header', 'getwid') . ' (Recomended)'; ?>
 			</label>
 			<p class="description"><?php
 				echo esc_html__('If this option is on, all CSS files of blocks will be moved to header for better theme compatibility. If your theme has custom styling for Getwid blocks, its styles will be applied first.', 'getwid');

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -236,7 +236,7 @@ class SettingsPage {
         ?>
 		<input type="number" id="getwid_section_content_width" name="getwid_section_content_width" value="<?php echo esc_attr( $field_val ); ?>" />
         <?php echo esc_html_x( 'px', 'pixels', 'getwid' ); ?>
-		<p class="description"><?php echo esc_html__( 'Default width of content area in the Section block. Leave empty to use $content_width set in your theme. Set 0 to disable this option and control it via CSS.', 'getwid' ); ?></p>
+		<p class="description"><?php echo esc_html__( 'Default width of the content area in the Section block. Leave empty to use $content_width set in your theme. Set 0 to disable this option and control it via CSS.', 'getwid' ); ?></p>
 		<?php
     }
 

--- a/languages/getwid.pot
+++ b/languages/getwid.pot
@@ -1,17 +1,17 @@
-# Copyright (C) 2022 MotoPress
-# This file is distributed under the same license as the Getwid plugin.
+# Copyright (C) 2023 MotoPress
+# This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Getwid 1.8.2\n"
+"Project-Id-Version: Getwid 1.8.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/getwid\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-06-29T17:01:28+03:00\n"
+"POT-Creation-Date: 2023-01-26T15:31:47+02:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: getwid\n"
 
 #. Plugin Name of the plugin
@@ -509,7 +509,7 @@ msgid "px"
 msgstr ""
 
 #: includes/settings-page.php:239
-msgid "Default width of content area in the Section block. Leave empty to use the width set in your theme."
+msgid "Default width of the content area in the Section block. Leave empty to use $content_width set in your theme. Set 0 to disable this option and control it via CSS."
 msgstr ""
 
 #: includes/settings-page.php:262

--- a/readme.txt
+++ b/readme.txt
@@ -182,6 +182,12 @@ Getwid plugin is distributed under the terms of the GNU GPL.
 
 == Changelog ==
 
+= 1.8.3, Jan 26 2023 =
+* Improved accessibility of the Video Popup block.
+* Added the ability to load block assets outside Getwid.
+* Fixed an issue with the Tabs block styles being broken when it's nested inside itself.
+* Fixed an issue with the Media Text Slider block not working properly in WP 6.1.
+
 = 1.8.2, Jun 29 2022 =
 * Added the ability to set the width of the cell borders in the Advanced Table block.
 * Added new parameters for the Content Slider block - Adaptive Height and Draggable.

--- a/src/blocks/media-text-slider/media-text-slider/edit.js
+++ b/src/blocks/media-text-slider/media-text-slider/edit.js
@@ -157,7 +157,7 @@ class Edit extends Component {
 		};
 
 		$.each( innerBlocksOuter, (index, item) => {
-			if ( isEqual( contentBlockId, item.innerBlocks[ 0 ].clientId ) ) {
+			if ( !!item.innerBlocks[ 0 ] && isEqual( contentBlockId, item.innerBlocks[ 0 ].clientId ) ) {
 				dispatch( 'core/block-editor' ).updateBlockAttributes( contentBlockId, { innerParent: InnerBlocksProps } );
 			}
 		} );

--- a/src/blocks/tabs/tabs/style.scss
+++ b/src/blocks/tabs/tabs/style.scss
@@ -2,7 +2,7 @@
  * getwid-tabs
  */
 
-.wp-block-getwid-tabs {
+ .wp-block-getwid-tabs {
 	//Specific variables for this block
 
 	$border_color: #ebeef1;
@@ -117,40 +117,39 @@
 	display: flex;
 	/*rtl:raw: flex-direction: row-reverse; */
 
-	.wp-block-getwid-tabs__nav-links {
+	> .wp-block-getwid-tabs__nav-links {
 		flex-direction: column;
 		align-items: initial;
 		/*rtl:raw: justify-content: flex-start; */
 		flex: 1 0 auto;
 		margin: 0 -1px 0 0;
 		max-width: 25%;
+
+		.wp-block-getwid-tabs__nav-link {
+			margin: 0 0 5px 0;
+			border: 1px solid #eee;
+			border-right: 0;
+
+			* {
+				word-wrap: break-word;
+				hyphens: auto;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 
-	.wp-block-getwid-tabs__nav-link {
-		margin: 0 0 5px 0;
-		border: 1px solid #eee;
-		border-right: 0;
-
-		* {
-			word-wrap: break-word;
-			hyphens: auto;
-		}
-
-		&:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-	.wp-block-getwid-tabs__tab-content {
-		flex: 0 1 auto;
-		min-width: 0;
+	> .wp-block-getwid-tabs__tab-content-wrapper {
+		flex: 1;
 	}
 }
 
 .has-layout-vertical-right {
 	flex-direction: row-reverse #{'/*rtl: row;*/'};
 
-	.wp-block-getwid-tabs__nav-links {
+	> .wp-block-getwid-tabs__nav-links {
 		margin: 0 0 0 -1px;
 
 		.wp-block-getwid-tabs__nav-link {
@@ -161,13 +160,13 @@
 }
 
 .has-layout-horizontal-center {
-	.wp-block-getwid-tabs__nav-links {
+	> .wp-block-getwid-tabs__nav-links {
 		justify-content: center;
 	}
 }
 
 .has-layout-horizontal-right {
-	.wp-block-getwid-tabs__nav-links {
+	> .wp-block-getwid-tabs__nav-links {
 		justify-content: flex-end #{'/*rtl: flex-start*/'};
 	}
 }

--- a/src/blocks/video-popup/edit.js
+++ b/src/blocks/video-popup/edit.js
@@ -91,7 +91,6 @@ class Edit extends Component {
 				id,
 				url,
 				title,
-				text,
 				link,
 				align,
 				minHeight,
@@ -247,6 +246,23 @@ class Edit extends Component {
 			}
 		};
 
+		const imgAttributes = {
+			src: url,
+			alt: '',
+			className: classnames(
+				`${baseClass}__image`,
+				`${baseClass}__source`,
+				(id ? `wp-image-${id}` : ''),
+			)
+		};
+
+		const hasTitle = !RichText.isEmpty(title);
+
+		if (hasTitle) {
+			linkAttributes['aria-label'] = title;
+			imgAttributes.alt = title;
+		}
+
 		const controls = (
 			<Fragment>
 				<BlockControls>
@@ -291,6 +307,8 @@ class Edit extends Component {
 			</Fragment>
 		);
 
+		console.log(imgAttributes);
+
 		return (
 			<Fragment>
 				<div {...wrapperProps}>
@@ -310,8 +328,7 @@ class Edit extends Component {
 					<a {...linkAttributes}>
 						<div {...containerProps}>
 							{!!url && (
-								<img src={url} alt=""
-									 className={`${baseClass}__image ${baseClass}__source ` + (id ? `wp-image-${id}` : '')}/>
+								<img {...imgAttributes}/>
 							)}
 							<div {...buttonProps}>
 								<div {...iconProps}>

--- a/src/blocks/video-popup/save.js
+++ b/src/blocks/video-popup/save.js
@@ -27,7 +27,6 @@ class Save extends Component {
 				id,
 				url,
 				title,
-				text,
 				link,
 				align,
 				minHeight,
@@ -141,21 +140,37 @@ class Save extends Component {
 			}
 		};
 
+		const imgAttributes = {
+			src: url,
+			alt: '',
+			className: classnames(
+				`${baseClass}__image`,
+				`${baseClass}__source`,
+				(id ? `wp-image-${id}` : ''),
+			)
+		};
+
+		const hasTitle = !RichText.isEmpty(title);
+
+		if (hasTitle) {
+			linkAttributes['aria-label'] = title;
+			imgAttributes.alt = title;
+		}
+
 		return (
 			<div {...wrapperProps}>
 				<a {...linkAttributes}>
 					<div {...containerProps}>
 						{!!url && (
-							<img src={url} alt=""
-								 className={`${baseClass}__image ${baseClass}__source ` + (id ? `wp-image-${id}` : '')}/>
+							<img {...imgAttributes}/>
 						)}
 						<div {...buttonProps}>
 							<div {...iconProps}>
-								<i className={`fas fa-play`}></i>
+								<i className={`fas fa-play`} aria-hidden="true"></i>
 							</div>
-							{(!!!url && (!RichText.isEmpty(title) || !RichText.isEmpty(text))) && (
+							{(!!!url && hasTitle) && (
 								<div className={`${baseClass}__button-caption`}>
-									{!RichText.isEmpty(title) && (
+									{hasTitle && (
 										<RichText.Content tagName="p" {...titleProps} value={title}/>
 									)}
 								</div>
@@ -165,7 +180,7 @@ class Save extends Component {
 				</a>
 				{url && (
 					<div className={`${baseClass}__caption`}>
-						{!RichText.isEmpty(title) && (
+						{hasTitle && (
 							<RichText.Content tagName="p" {...titleProps} value={title}/>
 						)}
 					</div>


### PR DESCRIPTION
- Improved accessibility for Video Popup block.
- Added ability to load block assets outside Getwid.
- Fixed an issue when the Tabs block styles are broken when it was nested inside itself.
- Fixed an issue when Media Text Slider block may not work properly in WP 6.1.