### PR TITLE
Hash expand

### DIFF
--- a/src/frontend/blocks/accordion/index.js
+++ b/src/frontend/blocks/accordion/index.js
@@ -5,12 +5,30 @@
 (function ($) {
 	$(document).ready(function (e) {
 
+		var getwid_window_hook = false;
+
 		//Init block loaded via AJAX
 		$(document.body).on('post-load', function (e) {
 			getwid_init_accordions();
 		});
 
 		var getwid_init_accordions = () => {
+			if( getwid_window_hook === false && $('.wp-block-getwid-accordion').length > 0 ) {
+				getwid_window_hook = true;
+
+				$(window).on('hashchange', function (e) {
+					if (window.location.hash) {
+						$('.wp-block-getwid-accordion.getwid-init .wp-block-getwid-accordion__header-wrapper' + window.location.hash).each(function (index, row) {
+							var $row = $(row);
+
+							if ( ! $row.hasClass('ui-accordion-header-active') ) {
+								$row.trigger('click');
+							}
+						});
+					}
+				});
+			}
+
 			var getwid_accordions = $('.wp-block-getwid-accordion:not(.getwid-init)'),
 				getwid_accordion_active = 0;
 

--- a/src/frontend/blocks/toggle/index.js
+++ b/src/frontend/blocks/toggle/index.js
@@ -5,12 +5,30 @@
 (function ($) {
 	$(document).ready(function (e) {
 
+		var getwid_window_hook = false;
+
 		//Init block loaded via AJAX
 		$(document.body).on('post-load', function (e) {
 			getwid_init_toggles();
 		});
 
 		var getwid_init_toggles = () => {
+			if( getwid_window_hook === false && $('.wp-block-getwid-toggle').length > 0 ) {
+				getwid_window_hook = true;
+
+				$(window).on('hashchange', function (e) {
+					if (window.location.hash) {
+						$('.wp-block-getwid-toggle.getwid-init .wp-block-getwid-toggle__row' + window.location.hash).each(function (index, row) {
+							var $row = $(row);
+
+							if ( ! $row.hasClass('is-active') ) {
+								$row.find('.wp-block-getwid-toggle__header-wrapper').trigger('click');
+							}
+						});
+					}
+				});
+			}
+
 			var getwid_toggles = $('.wp-block-getwid-toggle:not(.getwid-init)');
 
 			getwid_toggles.each(function (index, toggle) {
@@ -55,6 +73,10 @@
 						row.addClass('is-active');
 					}
 				});
+
+				if (window.location.hash) {
+					$(window).trigger('hashchange');
+				}
 			});
 		};
 


### PR DESCRIPTION
Followup of PR #92 use the anchor option to allow expansion of toggle/accordion item using window.location.hash

This is useful for when you want to link to a certain item on a page (ex. FAQ item 5) using the location hash. It then also makes sure that item is expanded.