### PR TITLE
Call `wp_localize_script` directly after enqueueing blocks-frontend-js

### DIFF
--- a/includes/scripts-manager.php
+++ b/includes/scripts-manager.php
@@ -30,8 +30,6 @@ class ScriptsManager {
 		// section_content_width inline styles
 		add_action( 'after_theme_setup', [ $this, 'enqueue_editor_section_css' ] );
 
-		add_action( 'wp_footer', [ $this, 'localizeFrontend' ] );
-
 		// Register frontend styles
 		add_action( 'wp_footer', [ $this, 'wp_late_enqueue_scripts' ] );
 	}
@@ -270,9 +268,7 @@ class ScriptsManager {
 			$this->version,
 			true
 		);
-	}
 
-	public function localizeFrontend() {
 		wp_localize_script(
 			"{$this->prefix}-blocks-frontend-js",
 			'Getwid',


### PR DESCRIPTION
I run into an issue with Getwid an TML where TML called `wp_print_footer_scripts` before the "wp_footer" action was called. This resulted in the scenario where the localization JS wasn't included in the page.

You can call `wp_localize_script( "<script name>" )` directly after registering or enqueueing it (eg. on the "enqueue_block_assets" action). That way WordPress handles it all and the additional "wp_footer" hook is not needed.

I guess it's safer that way...