### PR TITLE
Version: 2.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= 1.8.4, Apr 13 2023 =
+* Security - Improve URL checks in REST controller.
+
 = 1.8.3, Jan 26 2023 =
 * Improved accessibility of the Video Popup block.
 * Added the ability to load block assets outside Getwid.

--- a/getwid.php
+++ b/getwid.php
@@ -3,7 +3,7 @@
  * Plugin Name: Getwid
  * Plugin URI: https://motopress.com/products/getwid/
  * Description: Extra Gutenberg blocks for building seamless and aesthetic websites in the WordPress block editor.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: MotoPress
  * Author URI: https://motopress.com/
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: gutenberg, gutenberg blocks, wordpress blocks, blocks, editor, block, gute
 Requires at least: 5.8
 Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -188,6 +188,9 @@ Getwid plugin is distributed under the terms of the GNU GPL.
 
 == Changelog ==
 
+= 2.0.1, Sep 18 2023 =
+* Fixed an issue when the Table block didn't work correctly in WordPress 6.3.
+
 = 2.0.0, Aug 15 2023 =
 * Added full support of WordPress Full Site Editing.
 * Improved compatibility with the Gutenberg plugin 16.3.0.
@@ -213,9 +216,6 @@ Getwid plugin is distributed under the terms of the GNU GPL.
 = 1.8.5, Apr 14 2023 =
 * Fixed an issue when content of Section block may disappear in the block editor.
 * Fixed an issue when animation of Progress Bar and Circular Progress Bar blocks may not run in the block editor.
-
-= 1.8.4, Apr 13 2023 =
-* Security - Improve URL checks in REST controller.
 
 --------
 

--- a/src/blocks/media-text-slider/media-text-slider/edit.js
+++ b/src/blocks/media-text-slider/media-text-slider/edit.js
@@ -270,6 +270,7 @@ class Edit extends Component {
 								placeholder={ __( 'Slide', 'getwid' ) }
 								value={ sliderArraysParsed[ index ] ? typeof sliderArraysParsed[ index ].text !== 'undefined' ? sliderArraysParsed[ index ].text : sliderArraysParsed[ index ] : __( 'Slide', 'getwid' ) }
 								unstableOnFocus={() => changeState( 'currentSlide', 1 + index )}
+								onFocus={() => changeState( 'currentSlide', 1 + index )}
 								onChange={value => {
 									updateSlideLabel( value, index );
 								}}

--- a/src/blocks/table/edit.js
+++ b/src/blocks/table/edit.js
@@ -1021,6 +1021,22 @@ class GetwidTable extends Component {
 		}
 	}
 
+	onCellSelect(cell) {
+		const { updated } = this.state;
+		if ( !updated ) {
+			const { minColIdx, maxColIdx } = this.table.getIndices( cell.section, cell.rowIdx, cell.columnIdx );
+
+			this.setState({
+				selectedCell: {
+					...cell,
+					minColIdx: minColIdx,
+					maxColIdx: maxColIdx
+				},
+				selectedSection: cell.section
+			});
+		}
+	}
+
 	renderSection(section) {
 		const {
 			baseClass,
@@ -1132,21 +1148,8 @@ class GetwidTable extends Component {
 								className={ `${baseClass}__cell` }
 								value={ content }
 								onChange={ value => this.onUpdateTableContent( value ) }
-								unstableOnFocus={ () => {
-									const { updated } = this.state;
-									if ( !updated ) {
-										const { minColIdx, maxColIdx } = this.table.getIndices( section, rIndex, cIndex );
-
-										this.setState({
-											selectedCell: {
-												...cell,
-												minColIdx: minColIdx,
-												maxColIdx: maxColIdx
-											},
-											selectedSection: section
-										});
-									}
-								} }
+								unstableOnFocus={ () => this.onCellSelect( cell ) }
+								onFocus={ () => this.onCellSelect( cell ) }
 								allowedFormats={ selectedCell
 									? allowedFormats
 									: []
@@ -1268,6 +1271,13 @@ class GetwidTable extends Component {
 							setAttributes({ caption: value })
 						}
 						unstableOnFocus={ () =>
+							this.setState({
+								selectedCell: null,
+								rangeSelected: null,
+								multiSelected: null
+							})
+						}
+						onFocus={ () =>
 							this.setState({
 								selectedCell: null,
 								rangeSelected: null,


### PR DESCRIPTION
Fixed an issue when the Table block didn't work correctly in WordPress 6.3.